### PR TITLE
fix: fix for TmsRunSettings always overriding in config by default value

### DIFF
--- a/TmsRunner/Program.cs
+++ b/TmsRunner/Program.cs
@@ -57,6 +57,7 @@ public static class Program
                     TmsConfigFile = ac.TmsConfigFile,
                     TmsLabelsOfTestsToRun = ac.TmsLabelsOfTestsToRun,
                     TmsAutomaticCreationTestCases = ac.TmsAutomaticCreationTestCases,
+                    TmsRunSettings = ac.TmsRunSettings,
                     TmsAutomaticUpdationLinksToTestCases = ac.TmsAutomaticUpdationLinksToTestCases,
                     TmsCertValidation = ac.TmsCertValidation
                 };


### PR DESCRIPTION
There was the problem with TmsRunSettings, when we set it like this: --tmsRunSettings {YOUR SETTINGS}, it's always overriding by default value in [TmsRunner/Program.cs](https://github.com/testit-tms/adapters-dotnet/compare/fix/fix_set_runsettings_via_cli?expand=1#diff-c402b90bdea49c35a6fda7f665084dfee5cf2a1279578d247dfd0b95c646a0c8). Same problem existing also for env variables, need investigation