### PR TITLE
feat: TMS-31120: Add option for tests rerun via adapter

### DIFF
--- a/Tms.Adapter/README.md
+++ b/Tms.Adapter/README.md
@@ -40,6 +40,7 @@ dotnet package add TestIt.Adapter
 | Mode of automatic creation test cases (**It's optional**). Default value - false. The adapter supports following modes:<br/>true - in this mode, the adapter will create a test case linked to the created autotest (not to the updated autotest)<br/>false - in this mode, the adapter will not create a test case                                                                    | automaticCreationTestCases        | TMS_AUTOMATIC_CREATION_TEST_CASES          | tmsAutomaticCreationTestCases        |
 | Mode of automatic updation links to test cases (**It's optional**). Default value - false. The adapter supports following modes:<br/>true - in this mode, the adapter will update links to test cases<br/>false - in this mode, the adapter will not update link to test cases                                                                                                         | automaticUpdationLinksToTestCases | TMS_AUTOMATIC_UPDATION_LINKS_TO_TEST_CASES | tmsAutomaticUpdationLinksToTestCases |
 | List of labels for filtering tests (**Optional**). It will only work with adapter mode 2.                                                                                                                                                                                                                                                                                              | -                                 | -                                          | tmsLabelsOfTestsToRun                |
+| Number of times to rerun failed tests (**It's optional**). Default value - 0.                                                                                                                                                                                                                                                                                                          | rerunTestsCount                   | TMS_ADAPTER_AUTOTESTS_RERUN_COUNT          | tmsRerunTestsCount                   |
 
 #### File
 
@@ -56,7 +57,8 @@ Create **Tms.config.json** file in the project directory:
   "adapterMode": ADAPTER_MODE,
   "automaticCreationTestCases": AUTOMATIC_CREATION_TEST_CASES,
   "automaticUpdationLinksToTestCases": AUTOMATIC_UPDATION_LINKS_TO_TEST_CASES,
-  "certValidation": CERT_VALIDATION
+  "certValidation": CERT_VALIDATION,
+  "rerunTestsCount": RERUN_TESTS_COUNT
 }
 ```
 
@@ -66,7 +68,7 @@ Create **Tms.config.json** file in the project directory:
 
 ```
 TmsRunner --runner "/usr/local/share/dotnet/sdk/6.0.302/vstest.console.dll" --testassembly "/tests/MsTest.dll" --tmsUrl=http://localhost:8080 --tmsPrivateToken=Token --tmsProjectId=f5da5bab-380a-4382-b36f-600083fdd795 --tmsConfigurationId=3a14fa45-b54e-4859-9998-cc502d4cc8c6
--tmsAdapterMode=0 --tmsTestRunId=a17269da-bc65-4671-90dd-d3e3da92af80 --tmsTestRunName=Regress --tmsAutomaticCreationTestCases=true --tmsAutomaticUpdationLinksToTestCases=true --tmsCertValidation=true --tmsLabelsOfTestsToRun smoke,regress --debug
+-tmsAdapterMode=0 --tmsTestRunId=a17269da-bc65-4671-90dd-d3e3da92af80 --tmsTestRunName=Regress --tmsAutomaticCreationTestCases=true --tmsAutomaticUpdationLinksToTestCases=true --tmsCertValidation=true --tmsLabelsOfTestsToRun smoke,regress --debug --tmsRerunTestsCount=2
 ```
 
 * `runner` - path to vstest.console.dll or vstest.console.exe

--- a/TmsRunner/App.cs
+++ b/TmsRunner/App.cs
@@ -56,7 +56,15 @@ public class App(ILogger<App> logger,
         }
 
         logger.LogInformation("Running tests: {Count}", testCases.Count);
-        await runService.RunSelectedTestsAsync(testCases).ConfigureAwait(false);
+        
+        if (tmsSettings.RerunTestsCount > 0)
+        {
+            await runService.RunTestsWithRerunsAsync(testCases).ConfigureAwait(false);
+        }
+        else
+        {
+            await runService.RunSelectedTestsAsync(testCases).ConfigureAwait(false);
+        }
 
         if (tmsSettings.AdapterMode == 2)
         {

--- a/TmsRunner/Entities/Configuration/AdapterConfig.cs
+++ b/TmsRunner/Entities/Configuration/AdapterConfig.cs
@@ -78,6 +78,10 @@ public sealed class AdapterConfig
     [Option("tmsCertValidation", Default = "true", Required = false, HelpText = "Set certificate validation.")]
     public string? TmsCertValidation { get; init; }
 
+    [Option("tmsRerunTestsCount", Default = "0", Required = false, HelpText = "Number of times to rerun failed tests")]
+    public string? TmsRerunTestsCount { get; set; }
+
+
     public Config ToInternalConfig()
     {
         return new Config
@@ -94,8 +98,8 @@ public sealed class AdapterConfig
             TmsAutomaticCreationTestCases = TmsAutomaticCreationTestCases,
             TmsAutomaticUpdationLinksToTestCases = TmsAutomaticUpdationLinksToTestCases,
             TmsCertValidation = TmsCertValidation,
-            TmsLabelsOfTestsToRun = TmsLabelsOfTestsToRun
-
+            TmsLabelsOfTestsToRun = TmsLabelsOfTestsToRun,
+            TmsRerunTestsCount = TmsRerunTestsCount
         };
     }
 

--- a/TmsRunner/Entities/Configuration/ClassConfigurationProvider.cs
+++ b/TmsRunner/Entities/Configuration/ClassConfigurationProvider.cs
@@ -19,7 +19,8 @@ public sealed class ClassConfigurationProvider(Config config) : ConfigurationPro
             { "RunSettings", config.TmsRunSettings },
             { "AutomaticCreationTestCases", config.TmsAutomaticCreationTestCases },
             { "AutomaticUpdationLinksToTestCases", config.TmsAutomaticUpdationLinksToTestCases },
-            { "CertValidation", config.TmsCertValidation }
+            { "CertValidation", config.TmsCertValidation },
+            { "RerunTestsCount", config.TmsRerunTestsCount }
         };
 
         Data = data

--- a/TmsRunner/Entities/Configuration/Config.cs
+++ b/TmsRunner/Entities/Configuration/Config.cs
@@ -15,4 +15,5 @@ public sealed record Config
     public string? TmsAutomaticUpdationLinksToTestCases;
     public string? TmsCertValidation;
     public string? TmsLabelsOfTestsToRun;
+    public string? TmsRerunTestsCount;
 }

--- a/TmsRunner/Entities/Configuration/EnvConfigurationProvider.cs
+++ b/TmsRunner/Entities/Configuration/EnvConfigurationProvider.cs
@@ -15,6 +15,7 @@ public sealed class EnvConfigurationProvider : ConfigurationProvider
     private const string EnvTmsAutomaticCreationTestCases = "TMS_AUTOMATIC_CREATION_TEST_CASES";
     private const string EnvTmsAutomaticUpdationLinksToTestCases = "TMS_AUTOMATIC_UPDATION_LINKS_TO_TEST_CASES";
     private const string EnvTmsCertValidation = "TMS_CERT_VALIDATION";
+    private const string EnvTmsRerunTestsCount = "TMS_ADAPTER_AUTOTESTS_RERUN_COUNT";
 
     public override void Load()
     {
@@ -31,6 +32,7 @@ public sealed class EnvConfigurationProvider : ConfigurationProvider
             { "AutomaticCreationTestCases", Environment.GetEnvironmentVariable(EnvTmsAutomaticCreationTestCases) },
             { "AutomaticUpdationLinksToTestCases", Environment.GetEnvironmentVariable(EnvTmsAutomaticUpdationLinksToTestCases) },
             { "CertValidation", Environment.GetEnvironmentVariable(EnvTmsCertValidation) },
+            { "RerunTestsCount", Environment.GetEnvironmentVariable(EnvTmsRerunTestsCount) },
         };
 
         Data = data

--- a/TmsRunner/Entities/TmsSettings.cs
+++ b/TmsRunner/Entities/TmsSettings.cs
@@ -20,4 +20,5 @@ public sealed record TmsSettings
     public bool AutomaticCreationTestCases { get; set; }
     public bool AutomaticUpdationLinksToTestCases { get; set; }
     public bool CertValidation { get; set; }
+    public int RerunTestsCount { get; set; }
 }

--- a/TmsRunner/Program.cs
+++ b/TmsRunner/Program.cs
@@ -59,7 +59,8 @@ public static class Program
                     TmsAutomaticCreationTestCases = ac.TmsAutomaticCreationTestCases,
                     TmsRunSettings = ac.TmsRunSettings,
                     TmsAutomaticUpdationLinksToTestCases = ac.TmsAutomaticUpdationLinksToTestCases,
-                    TmsCertValidation = ac.TmsCertValidation
+                    TmsCertValidation = ac.TmsCertValidation,
+                    TmsRerunTestsCount = ac.TmsRerunTestsCount
                 };
             });
 

--- a/TmsRunner/Services/RunService.cs
+++ b/TmsRunner/Services/RunService.cs
@@ -54,4 +54,42 @@ public sealed class RunService(ILogger<RunService> logger,
         runEventHandler.WaitForEnd();
         await Task.WhenAll(runEventHandler.GetProcessTestResultsTasks()).ConfigureAwait(false);
     }
+    
+    public async Task RunTestsWithRerunsAsync(IEnumerable<TestCase> initialTestCases)
+    {
+        var currentRun = 1;
+        var maxRuns = (int.TryParse(config.TmsRerunTestsCount, out int rerunCount) ? rerunCount : 0) + 1; // +1 for initial run
+        var testCasesToRun = initialTestCases.ToList();
+
+        while (currentRun <= maxRuns && testCasesToRun.Any())
+        {
+            logger.LogInformation(
+                "Running tests (Attempt {CurrentRun} of {MaxRuns}), Number of tests: {TestCount}", 
+                currentRun, 
+                maxRuns, 
+                testCasesToRun.Count);
+
+            await RunSelectedTestsAsync(testCasesToRun);
+
+            if (currentRun < maxRuns)
+            {
+                testCasesToRun = runEventHandler.GetFailedTestCases().ToList();
+                runEventHandler.ClearFailedTestCases();
+                
+                if (testCasesToRun.Any())
+                {
+                    logger.LogInformation(
+                        "Found {FailedCount} failed tests to rerun", 
+                        testCasesToRun.Count);
+                }
+                else
+                {
+                    logger.LogInformation("No failed tests to rerun");
+                    break;
+                }
+            }
+
+            currentRun++;
+        }
+    }
 }


### PR DESCRIPTION
# Add support for rerunning failed tests

## Changes
- Added the ability to rerun failed tests a specified number of times
- Added new configuration parameter `tmsRerunTestsCount` to control the number of reruns
- Implemented test rerun logic in `RunService`
- Added tracking of failed tests in `RunEventHandler`

## Details
1. Added new configuration option:
   - `tmsRerunTestsCount` - specifies how many times failed tests should be rerun (default: 0)

2. Enhanced `RunService` with new functionality:
   - Added `RunTestsWithRerunsAsync` method to handle test reruns
   - Implemented logic to track and rerun only failed tests
   - Added proper logging for rerun attempts and results

3. Modified `RunEventHandler`:
   - Added thread-safe collection of failed tests
   - Added methods to get and clear failed test cases
   - Implemented tracking of failed tests during test execution

4. Updated `App.cs` to use the new rerun functionality when `tmsRerunTestsCount > 0`

## Usage
To use the rerun functionality, specify the number of reruns when running the adapter:
```bash
--tmsRerunTestsCount 2  # Will rerun failed tests up to 2 times
```

## Example Flow
1. All tests are run initially
2. Failed tests are collected
3. If there are failed tests and reruns remaining, only failed tests are run again
4. Process repeats until either:
   - All tests pass
   - Maximum number of reruns is reached
   - No failed tests remain

Each test run (including reruns) is reported to TMS with its results.
