### PR TITLE
fix: fix logic for no parameters + singleton testrun service for entire app

### DIFF
--- a/TmsRunner/Program.cs
+++ b/TmsRunner/Program.cs
@@ -61,7 +61,8 @@ public static class Program
                     TmsRunSettings = ac.TmsRunSettings,
                     TmsAutomaticUpdationLinksToTestCases = ac.TmsAutomaticUpdationLinksToTestCases,
                     TmsCertValidation = ac.TmsCertValidation,
-                    TmsRerunTestsCount = ac.TmsRerunTestsCount
+                    TmsRerunTestsCount = ac.TmsRerunTestsCount,
+                    TmsIgnoreParameters = ac.TmsIgnoreParameters
                 };
             });
 
@@ -165,7 +166,7 @@ public static class Program
                         new ConsoleParameters { LogFilePath = Path.Combine(Directory.GetCurrentDirectory(), "log.txt") }
                     ))
                     .AddTransient<RunService>()
-                    .AddTransient<ITestRunContextService, TestRunContextService>();
+                    .AddSingleton<ITestRunContextService, TestRunContextService>(); // we need to keep this singleton ofr entire app context 
             });
     }
 


### PR DESCRIPTION
1. Fix `TmsIgnoreParameters` when setting up through the CLI
2. Use a singleton instance for the test run context service, as we need it throughout the entire app once the test run has been set up.