### PR TITLE
Fix: Normalize parameter values by removing quotes in GetParametersFromReflection

### DIFF
--- a/TmsRunner/Utils/LogParser.cs
+++ b/TmsRunner/Utils/LogParser.cs
@@ -170,12 +170,15 @@ public sealed class LogParser(Replacer replacer)
             {
                 var paramValue = paramValues[i];
                 
-                if ((paramValue.StartsWith("\"", StringComparison.OrdinalIgnoreCase) 
-                    && paramValue.EndsWith("\"", StringComparison.OrdinalIgnoreCase)) 
-                    || (paramValue.StartsWith("'", StringComparison.OrdinalIgnoreCase) 
-                        && paramValue.EndsWith("'", StringComparison.OrdinalIgnoreCase)))
+                if (paramValue.Length >= 2)
                 {
-                    paramValue = paramValue[1..^1];
+                    var firstChar = paramValue[0];
+                    var lastChar = paramValue[^1];
+
+                    if ((firstChar == '"' && lastChar == '"') || (firstChar == '\'' && lastChar == '\''))
+                    {
+                        paramValue = paramValue[1..^1];
+                    }
                 }
 
                 parameters[method.Parameters[i]!] = paramValue;

--- a/TmsRunner/Utils/LogParser.cs
+++ b/TmsRunner/Utils/LogParser.cs
@@ -168,7 +168,17 @@ public sealed class LogParser(Replacer replacer)
             
             for (var i = 0; i < method.Parameters?.Count && i < paramValues.Count; i++)
             {
-                parameters[method.Parameters[i]!] = paramValues[i];
+                var paramValue = paramValues[i];
+                
+                if ((paramValue.StartsWith("\"", StringComparison.OrdinalIgnoreCase) 
+                    && paramValue.EndsWith("\"", StringComparison.OrdinalIgnoreCase)) 
+                    || (paramValue.StartsWith("'", StringComparison.OrdinalIgnoreCase) 
+                        && paramValue.EndsWith("'", StringComparison.OrdinalIgnoreCase)))
+                {
+                    paramValue = paramValue[1..^1];
+                }
+
+                parameters[method.Parameters[i]!] = paramValue;
             }
         }
         catch


### PR DESCRIPTION
This change addresses an issue where autotest parameters obtained via reflection were inconsistent with parameters extracted from logs, leading to problems in linking autotests to manual work items.
Problem:
Parameters extracted directly from test execution logs are typically stored without surrounding quotes.
When parameters cannot be obtained from logs, we fall back to using reflection via GetParametersFromReflection. In this scenario, string or char parameters often retain their defining quotes (e.g., "stringValue" or 'c').
This discrepancy meant that the same logical parameter could have two representations: parameterValue (from logs) and "parameterValue" or 'parameterValue' (from reflection).
As a result, when linking autotests to manual work items that also use parameters (which are expected without quotes), the system could create incorrect or duplicate links because parameterValue was not recognized as identical to "parameterValue".
Solution:
The GetParametersFromReflection method has been updated to normalize parameter values by removing leading and trailing quotes (both single ' and double ").
Specifically, if a parameter value obtained through reflection:
Starts and ends with a double quote (e.g., "someValue"), it's transformed to someValue.
Starts and ends with a single quote (e.g., 'c'), it's transformed to c.
This ensures that parameter values are consistent, regardless of whether they are sourced from logs or reflection. This consistent formatting resolves the issue of extraneous links being created in TestIT due to mismatched parameter representations.
Impact:
Improved accuracy in linking autotests to manual work items.
Consistent handling of parameter values across different retrieval methods.
Prevents the creation of unnecessary or incorrect associations in the TestIT.
This change ensures that parameters like "123" and 123 are treated as the same value, which is crucial for the correct mapping of test results.