### PR TITLE
Fix: Debug flag is not working

### DIFF
--- a/TmsRunner/Entities/Configuration/AdapterConfig.cs
+++ b/TmsRunner/Entities/Configuration/AdapterConfig.cs
@@ -102,7 +102,8 @@ public sealed class AdapterConfig
             TmsCertValidation = TmsCertValidation,
             TmsRerunTestsCount = TmsRerunTestsCount,
             TmsLabelsOfTestsToRun = TmsLabelsOfTestsToRun,
-            TmsIgnoreParameters = TmsIgnoreParameters
+            TmsIgnoreParameters = TmsIgnoreParameters,
+            IsDebug = IsDebug
         };
     }
 

--- a/TmsRunner/Entities/Configuration/ClassConfigurationProvider.cs
+++ b/TmsRunner/Entities/Configuration/ClassConfigurationProvider.cs
@@ -21,7 +21,8 @@ public sealed class ClassConfigurationProvider(Config config) : ConfigurationPro
             { "AutomaticCreationTestCases", config.TmsAutomaticCreationTestCases },
             { "AutomaticUpdationLinksToTestCases", config.TmsAutomaticUpdationLinksToTestCases },
             { "CertValidation", config.TmsCertValidation },
-            { "RerunTestsCount", config.TmsRerunTestsCount }
+            { "RerunTestsCount", config.TmsRerunTestsCount },
+            { "IsDebug", config.IsDebug.ToString() }
         };
 
         Data = data

--- a/TmsRunner/Entities/Configuration/Config.cs
+++ b/TmsRunner/Entities/Configuration/Config.cs
@@ -17,4 +17,5 @@ public sealed record Config
     public string? TmsLabelsOfTestsToRun;
     public string? TmsIgnoreParameters;
     public string? TmsRerunTestsCount;
+    public bool IsDebug;
 }


### PR DESCRIPTION
The --debug command-line flag was not correctly enabling the debug logging level. The IsDebug property was parsed from the arguments, but its value was not used to configure the logger, which was hardcoded to the Information level.
This change fixes the issue by correctly propagating the IsDebug flag through the configuration pipeline and using it to conditionally set the Serilog log level for the console.
Changes:
Added the IsDebug property to the Config record to hold the debug state.
Updated AdapterConfig to pass the IsDebug value when creating the internal Config object.
Propagated the IsDebug setting through the ClassConfigurationProvider to make it available to the application's configuration.
Refactored the CreateHostBuilder method in Program.cs to:
Parse the command-line arguments once at the beginning.
Use the IsDebug flag to set the console logger's level to Debug when the flag is present.
Register the parsed configuration as a singleton to avoid redundant parsing